### PR TITLE
fix missing dep on amigo_msgs for light bridge

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -11,10 +11,12 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>amigo_msgs</build_depend>
   <build_depend>text_to_speech</build_depend>
   <build_depend>tmc_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
 
+  <run_depend>amigo_msgs</run_depend>
   <run_depend>text_to_speech</run_depend>
   <run_depend>tmc_msgs</run_depend>
   <run_depend>std_msgs</run_depend>


### PR DESCRIPTION
amigo_msgs on hero. This is very wrong.