### PR TITLE
remove transformation

### DIFF
--- a/src/plan_node/manipulation_bridge.py
+++ b/src/plan_node/manipulation_bridge.py
@@ -46,9 +46,7 @@ class ManipulationBridge(object):
         success = True
 
         pose_quaternion = quaternion_from_euler(action.goal.roll, action.goal.pitch, action.goal.yaw)
-        static_quaternion = quaternion_from_euler(3.14159265359, -1.57079632679, 0)
-        final_quaternion = quaternion_multiply(pose_quaternion, static_quaternion)
-        pose = [action.goal.x, action.goal.y, action.goal.z], final_quaternion
+        pose = [action.goal.x, action.goal.y, action.goal.z], pose_quaternion
 
         ################################################################################################################
         # This piece of code is partially copied from Toyota software, it also uses the private functions (we're very


### PR DESCRIPTION
fixes https://github.com/tue-robotics/tue_robocup/issues/1125

The toyota tf frame in the palm of the robot uses a different convention from us. Previously this was done here. Now it is done using the grasp offset. issue 1125 was caused by this transformation being done twice